### PR TITLE
Populate SMS-Email Gateways into Call Sheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 src/.clasp.json
+src/private.js

--- a/src/code.js
+++ b/src/code.js
@@ -454,7 +454,6 @@ function createTransportationSheet() {
       r[2], // Badge
       r[10], // email
       r[12], // mobile phone
-      r[14], // sms gateway
     ]);
   }
 

--- a/src/code.js
+++ b/src/code.js
@@ -11,7 +11,6 @@ var TOKEN_DIALOG_TITLE = 'Set D4H API Token';
 var EMAIL_DIALOG_TITLE = 'Email Responding Roster';
 var SMS_DIALOG_TITLE = 'SMS Responding Roster';
 var SIDEBAR_TITLE = 'Example Sidebar';
-var DO_EMAIL = "dutyofficer@sanmateosar.org";
 
 var COLUMNS = [
   "Name",
@@ -582,6 +581,6 @@ function sendEmail(email, subject, body) {
     to: email,
     subject: subject,
     htmlBody: body,
-    cc: DO_EMAIL
+    cc: Session.getActiveUser().getEmail()
   })
 }

--- a/src/code.js
+++ b/src/code.js
@@ -1,3 +1,6 @@
+// Add this line with DO phone number to separate .js file in /src:
+// var DO_PHONE = "your #";
+
 var D4H_STRING = "D4H";
 var YNL_STRING = "Y / N / L";
 
@@ -266,7 +269,7 @@ function populateAllCall() {
       phoneFormat(person, "homephone"),
       phoneFormat(person, "mobilephone"),
       phoneFormat(person, "workphone"),
-      person.pager_email
+      getGateway(phoneFormat(person, "mobilephone"))
     ]);
 
     // sets those off call in D4H to red
@@ -359,6 +362,32 @@ function getAllCall() {
   return everyone;
 }
 
+function getGateway(phone) {
+  var phone1 = "1" + DO_PHONE.replace(/[^\d]/g, '');
+  var phone2 = "1" + phone.replace(/[^\d]/g, '');
+  var gateSearchString = "from:" + phone1 + "." + phone2;
+
+  var thread = GmailApp.search(gateSearchString, 0, 2)[0];
+  if (thread == undefined) {return null};
+  var message = thread.getMessages()[0];
+  var msgFrom = message.getFrom();
+  var msgTo = message.getTo();
+
+  if (msgFrom.indexOf(phone2) > -1) {return msgFrom};
+  if (msgTo.indexOf(phone2) > -1) {return msgTo};
+
+  return null;
+}
+
+function setGateway(cell) {
+  var gateway = getGateway(cell.getValue());
+  if (gateway == null) { return };
+  var range1 = SpreadsheetApp.getActiveRange();
+  var col = range1.getColumn();
+  var row = range1.getRow();
+  var range2 = SpreadsheetApp.getActiveSheet().getRange(row,col+2);
+  range2.setValue(gateway);
+}
 
 function getResponders() {
   var num_people = getAllCall().length;


### PR DESCRIPTION
New method `getGateway()` searches gmail to capture sms-email gateway and populates call sheet, not dependent on updating every member's d4h profile.  It does require DO's phone number, which is defined in separate .js, I used `private.js` in `.gitignore`.

TEST: Runtime populating all members with DO account.  I was only able to test 2 members from my google voice account.